### PR TITLE
fix: user code error handling

### DIFF
--- a/handler/rfc8628/strategy_hmacsha.go
+++ b/handler/rfc8628/strategy_hmacsha.go
@@ -30,8 +30,8 @@ func (h *DefaultDeviceStrategy) GenerateUserCode(ctx context.Context) (token str
 		return "", "", err
 	}
 	userCode := string(seq)
-	signUserCode, signErr := h.UserCodeSignature(ctx, userCode)
-	if signErr != nil {
+	signUserCode, err := h.UserCodeSignature(ctx, userCode)
+	if err != nil {
 		return "", "", err
 	}
 	return userCode, signUserCode, nil

--- a/storage/memory_test.go
+++ b/storage/memory_test.go
@@ -6,7 +6,6 @@ package storage
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
 	"github.com/ory/fosite"
@@ -14,8 +13,7 @@ import (
 
 func TestMemoryStore_Authenticate(t *testing.T) {
 	type fields struct {
-		Users      map[string]MemoryUserRelation
-		usersMutex sync.RWMutex
+		Users map[string]MemoryUserRelation
 	}
 	type args struct {
 		in0    context.Context
@@ -49,8 +47,7 @@ func TestMemoryStore_Authenticate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &MemoryStore{
-				Users:      tt.fields.Users,
-				usersMutex: tt.fields.usersMutex,
+				Users: tt.fields.Users,
 			}
 			if err := s.Authenticate(tt.args.in0, tt.args.name, tt.args.secret); err == nil || !errors.Is(err, tt.wantErr) {
 				t.Errorf("Authenticate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
The default strategy implementation has a bug with an error path for code signature generation.