### PR TITLE
fix: issues with the token exchange handlers

### DIFF
--- a/handler/rfc8693/access_token_type_handler.go
+++ b/handler/rfc8693/access_token_type_handler.go
@@ -144,7 +144,10 @@ func (c *AccessTokenTypeHandler) validate(ctx context.Context, request fosite.Ac
 	}
 
 	// Convert to flat session with only access token claims
-	tokenObject := session.AccessTokenClaimsMap()
+	tokenObject := make(map[string]interface{})
+	if os, ok := or.GetSession().(Session); ok {
+		tokenObject = os.AccessTokenClaimsMap()
+	}
 	tokenObject["client_id"] = or.GetClient().GetID()
 	tokenObject["scope"] = or.GetGrantedScopes()
 	tokenObject["aud"] = or.GetGrantedAudience()
@@ -186,6 +189,7 @@ func (c *AccessTokenTypeHandler) issue(ctx context.Context, request fosite.Acces
 	response.SetTokenType("bearer")
 	response.SetExpiresIn(c.getExpiresIn(request, fosite.AccessToken, c.AccessTokenLifespan, time.Now().UTC()))
 	response.SetScopes(request.GetGrantedScopes())
+	response.SetExtra("issued_token_type", AccessTokenType)
 
 	return nil
 }

--- a/handler/rfc8693/custom_jwt_type_handler.go
+++ b/handler/rfc8693/custom_jwt_type_handler.go
@@ -91,6 +91,8 @@ func (c *CustomJWTTypeHandler) PopulateTokenEndpointResponse(ctx context.Context
 		return err
 	}
 
+	responder.SetExtra("issued_token_type", requestedTokenType)
+
 	return nil
 }
 

--- a/handler/rfc8693/id_token_type_handler.go
+++ b/handler/rfc8693/id_token_type_handler.go
@@ -143,6 +143,7 @@ func (c *IDTokenTypeHandler) issue(ctx context.Context, request fosite.AccessReq
 
 	response.SetAccessToken(token)
 	response.SetTokenType("N_A")
+	response.SetExtra("issued_token_type", IDTokenType)
 
 	return nil
 }

--- a/handler/rfc8693/refresh_token_type_handler.go
+++ b/handler/rfc8693/refresh_token_type_handler.go
@@ -145,7 +145,10 @@ func (c *RefreshTokenTypeHandler) validate(ctx context.Context, request fosite.A
 	}
 
 	// Convert to flat session with only access token claims
-	tokenObject := session.AccessTokenClaimsMap()
+	tokenObject := make(map[string]interface{})
+	if os, ok := or.GetSession().(Session); ok {
+		tokenObject = os.AccessTokenClaimsMap()
+	}
 	tokenObject["client_id"] = or.GetClient().GetID()
 	tokenObject["scope"] = or.GetGrantedScopes()
 	tokenObject["aud"] = or.GetGrantedAudience()
@@ -173,6 +176,7 @@ func (c *RefreshTokenTypeHandler) issue(ctx context.Context, request fosite.Acce
 	response.SetTokenType("N_A")
 	response.SetExpiresIn(c.getExpiresIn(request, fosite.RefreshToken, c.RefreshTokenLifespan, time.Now().UTC()))
 	response.SetScopes(request.GetGrantedScopes())
+	response.SetExtra("issued_token_type", RefreshTokenType)
 
 	return nil
 }


### PR DESCRIPTION
- Missing 'issued_token_type'
- Use the access token session to build the normalized subject and actor token objects, instead of the request session