### PR TITLE
fix: form complete URI in flexible way

### DIFF
--- a/handler/rfc8628/device_authorize_handler.go
+++ b/handler/rfc8628/device_authorize_handler.go
@@ -5,6 +5,7 @@ package rfc8628
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	"github.com/ory/fosite"
@@ -57,8 +58,16 @@ func (d *DeviceAuthorizeHandler) HandleDeviceAuthorizeEndpointRequest(ctx contex
 	resp.SetDeviceCode(deviceCode)
 	resp.SetUserCode(userCode)
 	resp.SetVerificationURI(d.Config.GetRFC8628UserVerificationURL(ctx))
-	resp.SetVerificationURIComplete(d.Config.GetRFC8628UserVerificationURL(ctx) + "?user_code=" + userCode)
+	resp.SetVerificationURIComplete(d.formCompleteURI(d.Config.GetRFC8628UserVerificationURL(ctx), userCode))
 	resp.SetExpiresIn(int64(time.Until(expireAt).Seconds()))
 	resp.SetInterval(int(d.Config.GetDeviceAuthTokenPollingInterval(ctx).Seconds()))
 	return nil
+}
+
+func (d *DeviceAuthorizeHandler) formCompleteURI(verificationURI, userCode string) string {
+	u, _ := url.Parse(verificationURI)
+	qp := u.Query()
+	qp["user_code"] = []string{userCode}
+	u.RawQuery = qp.Encode()
+	return u.String()
 }


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

The issue is when implementor of GetRFC8628UserVerificationURL() return a URI having query string,
the full URI will have double query string since it is done using simple concatenation.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
