### PR TITLE
feat: handlers for verifiable credentials

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,6 +77,12 @@ type ResponseModeClient interface {
 	GetResponseModes() []ResponseModeType
 }
 
+// CredentialIssuerClient represents a client capable of handling requests in credential issuance context
+type CredentialIssuerClient interface {
+	// IsCredentialIssuerClient returns true, if this client is marked as credential issuer client.
+	IsCredentialIssuerClient() bool
+}
+
 // DefaultClient is a simple default implementation of the Client interface.
 type DefaultClient struct {
 	ID             string   `json:"id"`

--- a/compose/compose_userinfo_vc.go
+++ b/compose/compose_userinfo_vc.go
@@ -5,6 +5,7 @@ package compose
 
 import (
 	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/handler/verifiable"
 )
 
@@ -15,4 +16,28 @@ func OIDCUserinfoVerifiableCredentialFactory(config fosite.Configurator, storage
 		NonceManager: storage.(verifiable.NonceManager),
 		Config:       config,
 	}
+}
+
+// PreAuthorizeCodeTokenHandlerFactory creates handler for pre-authorize code flow at token endpoint
+func PreAuthorizeCodeTokenHandlerFactory(config fosite.Configurator, storage, strategy interface{}) interface{} {
+	return &verifiable.PreAuthorizeCodeTokenHandler{
+		AuthorizeCodeStrategy:  strategy.(oauth2.AuthorizeCodeStrategy),
+		AccessTokenStrategy:    strategy.(oauth2.AccessTokenStrategy),
+		RefreshTokenStrategy:   strategy.(oauth2.RefreshTokenStrategy),
+		TokenRevocationStorage: storage.(oauth2.TokenRevocationStorage),
+		Storage:                storage.(verifiable.Storage),
+		Config:                 config,
+	}
+}
+
+// CredentialNonceHandlerFactory creates handler to generate credential nonce at token endpoint
+func CredentialNonceHandlerFactory(config fosite.Configurator, storage, strategy interface{}) interface{} {
+	return &verifiable.CredentialNonceHandler{
+		Config: config,
+	}
+}
+
+// IssuerStateHandlerFactory creates handler for issuer_state at authorize endpoint
+func IssuerStateHandlerFactory(config fosite.Configurator, storage, strategy interface{}) interface{} {
+	return &verifiable.IssuerStateHandler{}
 }

--- a/handler/rfc9396/token_request_handler.go
+++ b/handler/rfc9396/token_request_handler.go
@@ -48,5 +48,6 @@ func (h *TokenRequestHandler) CanHandleTokenEndpointRequest(ctx context.Context,
 		string(fosite.GrantTypeJWTBearer),
 		string(fosite.GrantTypePassword),
 		string(fosite.GrantTypeTokenExchange),
+		string(fosite.GrantTypePreAuthorizeCode),
 		string(fosite.GrantTypeRefreshToken))
 }

--- a/handler/verifiable/cnonce_handler.go
+++ b/handler/verifiable/cnonce_handler.go
@@ -1,0 +1,70 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package verifiable
+
+import (
+	"context"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/ory/x/errorsx"
+)
+
+type CredentialNonceHandler struct {
+	Config interface {
+		fosite.VerifiableCredentialsNonceLifespanProvider
+	}
+}
+
+var _ fosite.TokenEndpointHandler = (*CredentialNonceHandler)(nil)
+
+// HandleTokenEndpointRequest handles an authorize request. If the handler is not responsible for handling
+// the request, this method should return ErrUnknownRequest and otherwise handle the request.
+func (c *CredentialNonceHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse is responsible for setting return values and should only be executed if
+// the handler's HandleTokenEndpointRequest did not return ErrUnknownRequest.
+func (c *CredentialNonceHandler) PopulateTokenEndpointResponse(ctx context.Context, request fosite.AccessRequester, response fosite.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	sess, ok := request.GetSession().(Session)
+	if !ok {
+		return errorsx.WithStack(fosite.ErrServerError.WithDebug("Failed to generate credential nonce because the session is not of the right type."))
+	}
+
+	// generate the nonce
+	nonce, err := GenerateNonce()
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithDebug("Failed to generate credential nonce."))
+	}
+
+	lifespan := c.Config.GetVerifiableCredentialsNonceLifespan(ctx)
+
+	// associate it with the session
+	sess.SetCredentialNonce(nonce, time.Now().Add(lifespan))
+
+	// return it as part of token response
+	response.SetExtra("c_nonce", nonce)
+	response.SetExtra("c_nonce_expires_in", int64(lifespan.Seconds()))
+	return nil
+}
+
+func (c *CredentialNonceHandler) CanSkipClientAuth(context.Context, fosite.AccessRequester) bool {
+	return false
+}
+
+func (c *CredentialNonceHandler) CanHandleTokenEndpointRequest(_ context.Context, requester fosite.AccessRequester) bool {
+	if c, ok := requester.GetClient().(fosite.CredentialIssuerClient); ok {
+		return c.IsCredentialIssuerClient()
+	}
+	return false
+}

--- a/handler/verifiable/flow_preauthcode_token.go
+++ b/handler/verifiable/flow_preauthcode_token.go
@@ -62,7 +62,7 @@ func (c *PreAuthorizeCodeTokenHandler) HandleTokenEndpointRequest(ctx context.Co
 	code := request.GetRequestForm().Get("pre-authorized_code")
 
 	signature := c.AuthorizeCodeStrategy.AuthorizeCodeSignature(ctx, code)
-	preAuthRequest, err := c.Storage.GetPreAuthorizeCodeSession(ctx, signature, request.GetSession())
+	preAuthRequest, err := c.Storage.GetPreAuthorizeSession(ctx, signature, request.GetSession())
 	if err != nil && errors.Is(err, fosite.ErrNotFound) {
 		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("Invalid Pre-Authorized Code or the Pre-Authorized Code has expired."))
 	} else if err != nil {

--- a/handler/verifiable/flow_preauthcode_token.go
+++ b/handler/verifiable/flow_preauthcode_token.go
@@ -1,0 +1,194 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package verifiable
+
+import (
+	"context"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/storage"
+	"github.com/ory/x/errorsx"
+	"github.com/pkg/errors"
+)
+
+var _ fosite.TokenEndpointHandler = (*PreAuthorizeCodeTokenHandler)(nil)
+
+type PreAuthorizeCodeTokenHandler struct {
+	AuthorizeCodeStrategy  oauth2.AuthorizeCodeStrategy
+	AccessTokenStrategy    oauth2.AccessTokenStrategy
+	RefreshTokenStrategy   oauth2.RefreshTokenStrategy
+	TokenRevocationStorage oauth2.TokenRevocationStorage
+	Storage                Storage
+	Config                 interface {
+		fosite.AccessTokenLifespanProvider
+		fosite.RefreshTokenLifespanProvider
+		fosite.ScopeStrategyProvider
+		fosite.AudienceStrategyProvider
+		fosite.RefreshTokenScopesProvider
+	}
+}
+
+// HandleTokenEndpointRequest handles an authorize request. If the handler is not responsible for handling
+// the request, this method should return ErrUnknownRequest and otherwise handle the request.
+func (c *PreAuthorizeCodeTokenHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(errorsx.WithStack(fosite.ErrUnknownRequest))
+	}
+
+	client := request.GetClient()
+
+	// Check whether client is allowed to use pre-authorize grant type
+	if !client.GetGrantTypes().Has(string(fosite.GrantTypePreAuthorizeCode)) {
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHintf(
+			"The OAuth 2.0 Client is not allowed to use authorization grant \"%s\".", fosite.GrantTypePreAuthorizeCode))
+	}
+
+	// Check scope requested
+	for _, scope := range request.GetRequestedScopes() {
+		if !c.Config.GetScopeStrategy(ctx)(client.GetScopes(), scope) {
+			return errors.WithStack(fosite.ErrInvalidScope.WithHintf("The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
+		}
+	}
+
+	// Check audience requested
+	if err := c.Config.GetAudienceStrategy(ctx)(client.GetAudience(), request.GetRequestedAudience()); err != nil {
+		return err
+	}
+
+	// load the session based on incoming pre-authorize_code request parameter
+	code := request.GetRequestForm().Get("pre-authorized_code")
+
+	signature := c.AuthorizeCodeStrategy.AuthorizeCodeSignature(ctx, code)
+	preAuthRequest, err := c.Storage.GetPreAuthorizeCodeSession(ctx, signature, request.GetSession())
+	if err != nil && errors.Is(err, fosite.ErrNotFound) {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("Invalid Pre-Authorized Code or the Pre-Authorized Code has expired."))
+	} else if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+	}
+
+	// The authorization server MUST verify that the pre-authorization code is valid
+	// This needs to happen after store retrieval for the session to be hydrated properly
+	if err := c.AuthorizeCodeStrategy.ValidateAuthorizeCode(ctx, request, code); err != nil {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithWrap(err).WithDebug(err.Error()))
+	}
+
+	// Check transaction code
+	incomingTxCode := request.GetRequestForm().Get("tx_code")
+	expectedTxCode := preAuthRequest.GetTxCode()
+
+	if len(expectedTxCode) == 0 && len(incomingTxCode) > 0 {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("Transaction Code is not required."))
+	} else if len(expectedTxCode) > 0 && len(incomingTxCode) == 0 {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("Transaction Code is required."))
+	} else if expectedTxCode != incomingTxCode {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("Transaction Code is mismatched."))
+	}
+
+	// Check whether user has authenticate the request
+	if preAuthRequest.GetUserAuthenticationStatus() != fosite.UserAuthenticationApproved {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("User has not been authenticated yet."))
+	}
+
+	// Copy necessary things from original pre-authorize request
+	request.SetSession(preAuthRequest.GetSession())
+	request.SetID(preAuthRequest.GetID())
+
+	atLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypePreAuthorizeCode, fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(atLifespan).Round(time.Second))
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse is responsible for setting return values and should only be executed if
+// the handler's HandleTokenEndpointRequest did not return ErrUnknownRequest.
+func (c *PreAuthorizeCodeTokenHandler) PopulateTokenEndpointResponse(ctx context.Context, request fosite.AccessRequester, response fosite.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	ctx, err := storage.MaybeBeginTx(ctx, c.TokenRevocationStorage)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+	}
+
+	defer func() {
+		if err != nil {
+			if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
+				err = errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebugf("error: %s; rollback error: %s", err, rollBackTxnErr))
+			}
+		}
+	}()
+
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.Config.GetAccessTokenLifespan(ctx)).Round(time.Second))
+	access, accessSignature, err := c.AccessTokenStrategy.GenerateAccessToken(ctx, request)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+	} else if err := c.TokenRevocationStorage.CreateAccessTokenSession(ctx, accessSignature, request.Sanitize([]string{})); err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+	}
+
+	var refresh, refreshSignature string
+	if c.canIssueRefreshToken(ctx, request) {
+		request.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().UTC().Add(c.Config.GetRefreshTokenLifespan(ctx)).Round(time.Second))
+		refresh, refreshSignature, err = c.RefreshTokenStrategy.GenerateRefreshToken(ctx, request)
+		if err != nil {
+			return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+		} else if err = c.TokenRevocationStorage.CreateRefreshTokenSession(ctx, refreshSignature, request.Sanitize([]string{})); err != nil {
+			return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+		}
+	}
+
+	if err = storage.MaybeCommitTx(ctx, c.TokenRevocationStorage); err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+	}
+
+	response.SetAccessToken(access)
+	response.SetTokenType("bearer")
+	atLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypePreAuthorizeCode, fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
+	response.SetExpiresIn(getExpiresIn(request, fosite.AccessToken, atLifespan, time.Now().UTC()))
+	response.SetScopes(request.GetGrantedScopes())
+	if refresh != "" {
+		response.SetExtra("refresh_token", refresh)
+	}
+	return nil
+}
+
+// canIssueRefreshToken is used to check whether to generate refresh token
+func (c *PreAuthorizeCodeTokenHandler) canIssueRefreshToken(ctx context.Context, request fosite.Requester) bool {
+	// Require one of the refresh token scopes, if set.
+	scopes := c.Config.GetRefreshTokenScopes(ctx)
+	if len(scopes) > 0 && !request.GetGrantedScopes().HasOneOf(scopes...) {
+		return false
+	}
+	// Do not issue a refresh token to clients that cannot use the refresh token grant type.
+	if !request.GetClient().GetGrantTypes().Has("refresh_token") {
+		return false
+	}
+	return true
+}
+
+// CanSkipClientAuth indicates if client authentication can be skipped. By default it MUST be false, unless you are
+// implementing extension grant type, which allows unauthenticated client. CanSkipClientAuth must be called
+// before HandleTokenEndpointRequest to decide, if AccessRequester will contain authenticated client.
+func (c *PreAuthorizeCodeTokenHandler) CanSkipClientAuth(ctx context.Context, requester fosite.AccessRequester) bool {
+	// the specification mentioned that client authentication is optional
+	// however, for this implementation we requires it.
+	return false
+}
+
+// CanHandleRequest indicates, if TokenEndpointHandler can handle this request or not. If true,
+// HandleTokenEndpointRequest can be called.
+func (c *PreAuthorizeCodeTokenHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) bool {
+	// grant_type REQUIRED.
+	return requester.GetGrantTypes().ExactOne("urn:ietf:params:oauth:grant-type:pre-authorized_code")
+}
+
+func getExpiresIn(r fosite.Requester, key fosite.TokenType, defaultLifespan time.Duration, now time.Time) time.Duration {
+	if r.GetSession().GetExpiresAt(key).IsZero() {
+		return defaultLifespan
+	}
+	return time.Duration(r.GetSession().GetExpiresAt(key).UnixNano() - now.UnixNano())
+}

--- a/handler/verifiable/flow_preauthcode_token.go
+++ b/handler/verifiable/flow_preauthcode_token.go
@@ -62,7 +62,7 @@ func (c *PreAuthorizeCodeTokenHandler) HandleTokenEndpointRequest(ctx context.Co
 	code := request.GetRequestForm().Get("pre-authorized_code")
 
 	signature := c.AuthorizeCodeStrategy.AuthorizeCodeSignature(ctx, code)
-	preAuthRequest, err := c.Storage.GetPreAuthorizeSession(ctx, signature, request.GetSession())
+	preAuthRequest, err := c.Storage.GetPreAuthorizeSession(ctx, signature, request.GetSession(), true)
 	if err != nil && errors.Is(err, fosite.ErrNotFound) {
 		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("Invalid Pre-Authorized Code or the Pre-Authorized Code has expired."))
 	} else if err != nil {

--- a/handler/verifiable/flow_preauthcode_token.go
+++ b/handler/verifiable/flow_preauthcode_token.go
@@ -95,10 +95,6 @@ func (c *PreAuthorizeCodeTokenHandler) HandleTokenEndpointRequest(ctx context.Co
 	// Copy necessary things from original pre-authorize request
 	request.SetSession(preAuthRequest.GetSession())
 	request.SetID(preAuthRequest.GetID())
-
-	atLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypePreAuthorizeCode, fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
-	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(atLifespan).Round(time.Second))
-
 	return nil
 }
 
@@ -122,7 +118,10 @@ func (c *PreAuthorizeCodeTokenHandler) PopulateTokenEndpointResponse(ctx context
 		}
 	}()
 
-	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.Config.GetAccessTokenLifespan(ctx)).Round(time.Second))
+	atLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypePreAuthorizeCode,
+		fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(atLifespan).Round(time.Second))
+
 	access, accessSignature, err := c.AccessTokenStrategy.GenerateAccessToken(ctx, request)
 	if err != nil {
 		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
@@ -132,7 +131,10 @@ func (c *PreAuthorizeCodeTokenHandler) PopulateTokenEndpointResponse(ctx context
 
 	var refresh, refreshSignature string
 	if c.canIssueRefreshToken(ctx, request) {
-		request.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().UTC().Add(c.Config.GetRefreshTokenLifespan(ctx)).Round(time.Second))
+		rtLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypePreAuthorizeCode,
+			fosite.RefreshToken, c.Config.GetRefreshTokenLifespan(ctx))
+		request.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().UTC().Add(rtLifespan).Round(time.Second))
+
 		refresh, refreshSignature, err = c.RefreshTokenStrategy.GenerateRefreshToken(ctx, request)
 		if err != nil {
 			return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
@@ -147,7 +149,6 @@ func (c *PreAuthorizeCodeTokenHandler) PopulateTokenEndpointResponse(ctx context
 
 	response.SetAccessToken(access)
 	response.SetTokenType("bearer")
-	atLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypePreAuthorizeCode, fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
 	response.SetExpiresIn(getExpiresIn(request, fosite.AccessToken, atLifespan, time.Now().UTC()))
 	response.SetScopes(request.GetGrantedScopes())
 	if refresh != "" {

--- a/handler/verifiable/issuer_state_handler.go
+++ b/handler/verifiable/issuer_state_handler.go
@@ -1,0 +1,32 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package verifiable
+
+import (
+	"context"
+
+	"github.com/ory/fosite"
+)
+
+var _ fosite.AuthorizeEndpointHandler = (*IssuerStateHandler)(nil)
+
+// IssuerStateHandler handles additional 'issuer_state' request parameter in credential issuer context
+type IssuerStateHandler struct{}
+
+func (h *IssuerStateHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
+	client, ok := ar.GetClient().(fosite.CredentialIssuerClient)
+	if !ok || !client.IsCredentialIssuerClient() {
+		return nil // do nothing
+	}
+
+	sess, ok := ar.GetSession().(Session)
+	if !ok {
+		return nil
+	}
+
+	if is := ar.GetRequestForm().Get("issuer_state"); len(is) > 0 {
+		sess.SetIssuerState(is) // associate it with the session
+	}
+	return nil
+}

--- a/handler/verifiable/session.go
+++ b/handler/verifiable/session.go
@@ -1,0 +1,28 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package verifiable
+
+import "time"
+
+type Session interface {
+
+	// In the context of credential issuance with grant_type 'authorization_code'
+	// There is parameter 'issuer_state' to bind the authorization request with a Credential Issuer context
+
+	// GetIssuerState retrieve 'issuer_state' from the session
+	GetIssuerState() string
+
+	// SetIssuerState associates 'issuer_state' with the session
+	SetIssuerState(state string)
+
+	// CredentialNonceHandler will generate 'c_nonce' and associated it with token's session
+	// During introspection of the token, information about the nonce can be returned
+	// This model allows for decoupling between Credential Issuer and Authorization Server.
+
+	// GetCredentialNonce returns the 'c_nonce' associated with the session and the expiredAt
+	GetCredentialNonce() (string, time.Time)
+
+	// SetCredentialNonce associates the 'c_nonce' with the session
+	SetCredentialNonce(c_nonce string, expiresAt time.Time)
+}

--- a/handler/verifiable/storage.go
+++ b/handler/verifiable/storage.go
@@ -11,8 +11,8 @@ import (
 
 type Storage interface {
 
-	// GetPreAuthorizeCodeSession returns pre-authorize code session
+	// GetPreAuthorizeSession returns pre-authorize code session
 	// since the specification says pre-authorize code can only be used once,
 	// implementation of this method may delete the session right away from persistence storage
-	GetPreAuthorizeCodeSession(ctx context.Context, signature string, session fosite.Session) (request fosite.PreAuthorizeCodeRequester, err error)
+	GetPreAuthorizeSession(ctx context.Context, signature string, session fosite.Session) (request fosite.PreAuthorizeRequester, err error)
 }

--- a/handler/verifiable/storage.go
+++ b/handler/verifiable/storage.go
@@ -1,0 +1,18 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package verifiable
+
+import (
+	"context"
+
+	"github.com/ory/fosite"
+)
+
+type Storage interface {
+
+	// GetPreAuthorizeCodeSession returns pre-authorize code session
+	// since the specification says pre-authorize code can only be used once,
+	// implementation of this method may delete the session right away from persistence storage
+	GetPreAuthorizeCodeSession(ctx context.Context, signature string, session fosite.Session) (request fosite.PreAuthorizeCodeRequester, err error)
+}

--- a/handler/verifiable/storage.go
+++ b/handler/verifiable/storage.go
@@ -11,8 +11,7 @@ import (
 
 type Storage interface {
 
-	// GetPreAuthorizeSession returns pre-authorize code session
-	// since the specification says pre-authorize code can only be used once,
-	// implementation of this method may delete the session right away from persistence storage
-	GetPreAuthorizeSession(ctx context.Context, signature string, session fosite.Session) (request fosite.PreAuthorizeRequester, err error)
+	// GetPreAuthorizeSession returns pre-authorize session
+	// When revokeSession is true, after successful retrieval of the session, the session should be deleted right away
+	GetPreAuthorizeSession(ctx context.Context, signature string, session fosite.Session, revokeSession bool) (request fosite.PreAuthorizeRequester, err error)
 }

--- a/handler/verifiable/utils.go
+++ b/handler/verifiable/utils.go
@@ -1,0 +1,20 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package verifiable
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+func GenerateNonce() (string, error) {
+	nonceBytes := make([]byte, 32)
+	_, err := rand.Read(nonceBytes)
+	if err != nil {
+		return "", fmt.Errorf("unable to generate nonce")
+	}
+
+	return base64.RawURLEncoding.EncodeToString(nonceBytes), nil
+}

--- a/oauth2.go
+++ b/oauth2.go
@@ -18,6 +18,8 @@ type TokenType string
 
 type GrantType string
 
+type UserAuthenticationStatus int
+
 const (
 	AccessToken   TokenType = "access_token"
 	RefreshToken  TokenType = "refresh_token"
@@ -35,10 +37,15 @@ const (
 	GrantTypeAuthorizationCode GrantType = "authorization_code"
 	GrantTypePassword          GrantType = "password"
 	GrantTypeClientCredentials GrantType = "client_credentials"
-	GrantTypeJWTBearer         GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"     //nolint:gosec // this is not a hardcoded credential
-	GrantTypeTokenExchange     GrantType = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a hardcoded credential
-	GrantTypeDeviceCode        GrantType = "urn:ietf:params:oauth:grant-type:device_code"    //nolint:gosec // this is not a hardcoded credential
+	GrantTypeJWTBearer         GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"          //nolint:gosec // this is not a hardcoded credential
+	GrantTypeTokenExchange     GrantType = "urn:ietf:params:oauth:grant-type:token-exchange"      //nolint:gosec // this is not a hardcoded credential
+	GrantTypeDeviceCode        GrantType = "urn:ietf:params:oauth:grant-type:device_code"         //nolint:gosec // this is not a hardcoded credential
+	GrantTypePreAuthorizeCode  GrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code" //nolint:gosec // this is not a hardcoded credential
 	BearerAccessToken          string    = "bearer"
+
+	UserAuthenticationPending UserAuthenticationStatus = iota
+	UserAuthenticationDenied
+	UserAuthenticationApproved
 )
 
 // OAuth2Provider is an interface that enables you to write OAuth2 handlers with only a few lines of code.
@@ -396,6 +403,19 @@ type DeviceAuthorizeRequester interface {
 	GetStatus() DeviceAuthorizeStatus
 	SetLastChecked(lastChecked time.Time)
 	GetLastChecked() time.Time
+	Requester
+}
+
+// PreAuthorizeCodeRequester is a pre-authorize endpoint's request context
+type PreAuthorizeCodeRequester interface {
+	// SetTxCode sets the transaction code
+	SetTxCode(txCode string)
+	// GetTxCode gets the transaction code
+	GetTxCode() string
+	// SetUserAuthenticationStatus sets the authentication status: pending, failed, success
+	SetUserAuthenticationStatus(status UserAuthenticationStatus)
+	// GetUserAuthenticationStatus gets the current authentication status
+	GetUserAuthenticationStatus() UserAuthenticationStatus
 	Requester
 }
 

--- a/oauth2.go
+++ b/oauth2.go
@@ -406,8 +406,8 @@ type DeviceAuthorizeRequester interface {
 	Requester
 }
 
-// PreAuthorizeCodeRequester is a pre-authorize endpoint's request context
-type PreAuthorizeCodeRequester interface {
+// PreAuthorizeRequester is a pre-authorize endpoint's request context
+type PreAuthorizeRequester interface {
 	// SetTxCode sets the transaction code
 	SetTxCode(txCode string)
 	// GetTxCode gets the transaction code


### PR DESCRIPTION
The context is authorization server for credential issuance, especially
when the authorization server is separate entity from credential issuer.

There are additional parameters that need to be processed or verified; such as c_nonce, issuer_state.
The approach taken here is to associate those parameters in the session, so it should be retrievable and output
when access token is introspected by credential issuer.

The PR introduce the following:
- a new type of client to indicate that the client is able to process/produce additional information in regards to credential issuance
- a new grant type for pre authorize code flow
- handler to process issuer_state at the /authorize endpoint that persist the parameter into session
- handler to generate c_nonce at /token endpoint and persist it into session for verification later on
- handler for pre authorize code flow at /token endpoint to exchange pre-authorize code and tx_code for access token (and refresh token)

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
