### PR TITLE
fix: json serialization of rar having nulls

### DIFF
--- a/handler/rfc9396/authorize_handler.go
+++ b/handler/rfc9396/authorize_handler.go
@@ -106,7 +106,7 @@ func validateAndEnrichRequester(ctx context.Context, c fosite.Client, req fosite
 		}
 
 		if client != nil && strategy != nil && !strategy(client.GetAuthorizationDetailTypes(), ad.Type) {
-			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf("The OAuth 2.0 Client is not allowed to request authorization details of type '%s'.", ad.Type))
+			return errorsx.WithStack(fosite.ErrInvalidAuthorizationDetails.WithHintf("The OAuth 2.0 Client is not allowed to request authorization details of type '%s'.", ad.Type))
 		}
 
 		ad.DecorateWithTypeHandler(ctx, config)

--- a/handler/rfc9396/custom_authorization_details_test.go
+++ b/handler/rfc9396/custom_authorization_details_test.go
@@ -13,40 +13,8 @@ type PaymentInitiationTypeHandler struct {
 	fosite.RFC9396DefaultAuthorizationDetailsTypeHandler
 }
 
-func (h *PaymentInitiationTypeHandler) Equals(t1, t2 *fosite.RFC9396AuthorizationDetailsType) bool {
-	if len(t1.Extra) != len(t2.Extra) {
-		return false
-	}
-
-	instructedAmount1 := fosite.Map(t1.Extra).SafeMap("instructedAmount", nil)
-	instructedAmount2 := fosite.Map(t2.Extra).SafeMap("instructedAmount", nil)
-	if fosite.Map(instructedAmount1).SafeString("currency", "") != fosite.Map(instructedAmount2).SafeString("currency", "") {
-		return false
-	}
-
-	if fosite.Map(instructedAmount1).SafeString("amount", "") != fosite.Map(instructedAmount2).SafeString("amount", "") {
-		return false
-	}
-
-	if fosite.Map(t1.Extra).SafeString("creditorName", "") != fosite.Map(t2.Extra).SafeString("creditorName", "") {
-		return false
-	}
-
-	creditorAccount1 := fosite.Map(t1.Extra).SafeMap("creditorAccount", nil)
-	creditorAccount2 := fosite.Map(t2.Extra).SafeMap("creditorAccount", nil)
-	if fosite.Map(creditorAccount1).SafeString("bic", "") != fosite.Map(creditorAccount2).SafeString("bic", "") {
-		return false
-	}
-
-	if fosite.Map(creditorAccount1).SafeString("iban", "") != fosite.Map(creditorAccount2).SafeString("iban", "") {
-		return false
-	}
-
-	if fosite.Map(t1.Extra).SafeString("remittanceInformationUnstructured", "") != fosite.Map(t2.Extra).SafeString("remittanceInformationUnstructured", "") {
-		return false
-	}
-
-	return h.RFC9396DefaultAuthorizationDetailsTypeHandler.Equals(t1, t2)
+func (h *PaymentInitiationTypeHandler) GetID(t *fosite.RFC9396AuthorizationDetailsType) (string, error) {
+	return h.RFC9396DefaultAuthorizationDetailsTypeHandler.GetID(t)
 }
 
 func (h *PaymentInitiationTypeHandler) Validate(t *fosite.RFC9396AuthorizationDetailsType) error {

--- a/rfc9396_authorization_details.go
+++ b/rfc9396_authorization_details.go
@@ -100,12 +100,23 @@ func (ad *RFC9396AuthorizationDetailsType) UnmarshalJSON(data []byte) error {
 
 func (ad *RFC9396AuthorizationDetailsType) MarshalJSON() ([]byte, error) {
 	m := map[string]interface{}{
-		"type":       ad.Type,
-		"actions":    ad.Actions,
-		"datatypes":  ad.Datatypes,
-		"identifier": ad.Identifier,
-		"locations":  ad.Locations,
-		"privileges": ad.Privileges,
+		"type": ad.Type,
+	}
+
+	if len(ad.Actions) > 0 {
+		m["actions"] = ad.Actions
+	}
+	if len(ad.Datatypes) > 0 {
+		m["datatypes"] = ad.Datatypes
+	}
+	if len(ad.Identifier) > 0 {
+		m["identifier"] = ad.Identifier
+	}
+	if len(ad.Locations) > 0 {
+		m["locations"] = ad.Locations
+	}
+	if len(ad.Privileges) > 0 {
+		m["privileges"] = ad.Privileges
 	}
 
 	for k, v := range ad.Extra {


### PR DESCRIPTION
Few fixes:
- When doing JSON serialization of type RFC9396AuthorizationDetailsType, default properties that happen not to have value like actions, privileges show as null. 
- In the RAR validation, there is one line throwing ErrInvalidScope instead of ErrInvalidAuthorizationDetails.
- Minor: the example test PaymentInitiationTypeHandler implement wrong interface that was changed in last commit.

## Related Issue or Design Document

N/A

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
